### PR TITLE
fix: invoke oneway after socket closed (breaking)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 test/fixtures
+coverage
 examples/**/app/public
 logs
 run

--- a/lib/base.js
+++ b/lib/base.js
@@ -13,8 +13,6 @@ const defaultOptions = {
   heartbeatInterval: 5000,
   needHeartbeat: true,
   concurrent: 0,
-  reConnectTimes: 0,
-  reConnectInterval: 1000,
   logger: console,
 };
 const noop = () => {};
@@ -32,9 +30,6 @@ class TCPBase extends Base {
    *   - {Boolean} [noDelay] - whether use the Nagle algorithm or not，defaults to true
    *   - {Number} [concurrent] - the number of concurrent packet, defaults to zero, means no limit
    *   - {Number} [responseTimeout] - limit the maximum time for waiting a response
-   *   - {Number} [reConnectTimes] - the maximum number of times the client will automatically try to
-   *                                 reconnect to the remote server if the connection is dropped
-   *   - {Number} [reConnectInterval] - the auto-reconnect interval, defaults to 1s
    *   - {Logger} [logger] - the logger client
    * @constructor
    */
@@ -50,7 +45,6 @@ class TCPBase extends Base {
     }
 
     this.clientId = ++seed;
-    this._reConnectTimes = this.options.reConnectTimes;
     this._heartbeatTimer = null;
     this._socket = null;
     this._header = null;
@@ -184,23 +178,26 @@ class TCPBase extends Base {
    * @return {void}
    */
   send(packet, callback = noop) {
-    if (packet.oneway) {
-      if (!this._writable) {
-        const err = new Error('[TCPBase] the socket is not writable while sending a oneway packet');
-        err.id = packet.id;
-        err.data = packet.data.toString('base64');
+    if (!this._socket) {
+      const err = new Error(`[TCPBase] The socket was closed. (address: ${this[addressKey]})`);
+      err.id = packet.id;
+      err.data = packet.data.toString('base64');
+      if (packet.oneway) {
+        err.oneway = true;
+        callback();
         this.emit('error', err);
       } else {
-        this._socket.write(packet.data);
+        callback(err);
       }
+      return;
+    }
+    if (packet.oneway) {
+      this._socket.write(packet.data);
       callback();
       return;
     }
     if (!this._writable) {
       this._queue.push([ packet, callback ]);
-      if (!this._socket && !this._reConnectTimes) {
-        this._cleanQueue();
-      }
       return;
     }
     const meta = {
@@ -363,22 +360,20 @@ class TCPBase extends Base {
       clearInterval(this._heartbeatTimer);
       this._heartbeatTimer = null;
     }
-    // auto-reconnect
-    if (this._reConnectTimes) {
-      setTimeout(() => {
-        this._reConnectTimes--;
-        this._connect(err => {
-          if (!err) {
-            this._reConnectTimes = this.options.reConnectTimes;
-            // try to recover
-            this._resume();
-          }
-        });
-      }, this.options.reConnectInterval);
-      return;
-    }
     this._cleanQueue(this._lastError);
     this.emit('close');
+  }
+
+  _handleReadable() {
+    this._lastReceiveDataTime = Date.now();
+    try {
+      let remaining = false;
+      do {
+        remaining = this._readPacket();
+      } while (remaining);
+    } catch (err) {
+      this.close(err);
+    }
   }
 
   _connect(done) {
@@ -389,19 +384,8 @@ class TCPBase extends Base {
     }
     const socket = this._socket = net.connect(this.options.port, this.options.host);
     socket.setNoDelay(this.options.noDelay);
-    socket.on('readable', () => {
-      this._lastReceiveDataTime = Date.now();
-      try {
-        let remaining = false;
-        do {
-          remaining = this._readPacket();
-        } while (remaining);
-      } catch (err) {
-        this.close(err);
-      }
-    });
-
-    socket.once('close', () => this._handleClose());
+    socket.on('readable', () => { this._handleReadable(); });
+    socket.once('close', () => { this._handleClose(); });
     socket.once('error', err => {
       err.message += ' (address: ' + this[addressKey] + ')';
       this._lastError = err;

--- a/lib/base.js
+++ b/lib/base.js
@@ -8,6 +8,7 @@ const Base = require('sdk-base');
 const addressKey = Symbol('address');
 const defaultOptions = {
   noDelay: true,
+  connectTimeout: 3000,
   responseTimeout: 3000,
   heartbeatInterval: 5000,
   needHeartbeat: true,
@@ -54,6 +55,7 @@ class TCPBase extends Base {
     this._socket = null;
     this._header = null;
     this._bodyLength = null;
+    this._lastError = null;
     this._queue = [];
     this._invokes = new Map();
     this[addressKey] = this.options.host + ':' + this.options.port;
@@ -61,6 +63,11 @@ class TCPBase extends Base {
     this._lastReceiveDataTime = 0;
 
     this._connect();
+    this.ready(err => {
+      if (!err && this.options.needHeartbeat) {
+        this._startHeartbeat();
+      }
+    });
   }
 
   /**
@@ -176,15 +183,19 @@ class TCPBase extends Base {
    * @param {Function} [callback] - Call this function，when processing is complete, optional.
    * @return {void}
    */
-  send(packet, callback) {
-    callback = callback || noop;
-
+  send(packet, callback = noop) {
     if (packet.oneway) {
-      this._socket.write(packet.data);
+      if (!this._writable) {
+        const err = new Error('[TCPBase] the socket is not writable while sending a oneway packet');
+        err.id = packet.id;
+        err.data = packet.data.toString('base64');
+        this.emit('error', err);
+      } else {
+        this._socket.write(packet.data);
+      }
       callback();
       return;
     }
-
     if (!this._writable) {
       this._queue.push([ packet, callback ]);
       if (!this._socket && !this._reConnectTimes) {
@@ -333,25 +344,20 @@ class TCPBase extends Base {
    */
   close(err) {
     if (!this._socket) {
-      return;
+      return Promise.resolve();
     }
-    this._socket.destroy();
-    this._handleClose(err);
+    this._socket.destroy(err);
+    return this.await('close');
   }
 
-  _handleClose(err) {
+  _handleClose() {
     if (!this._socket) {
       return;
     }
-
     this._socket.removeAllListeners();
     this._socket = null;
 
-    if (err) {
-      this.emit('error', err);
-    }
-
-    this._cleanInvokes(err);
+    this._cleanInvokes(this._lastError);
     // clean timer
     if (this._heartbeatTimer) {
       clearInterval(this._heartbeatTimer);
@@ -361,24 +367,26 @@ class TCPBase extends Base {
     if (this._reConnectTimes) {
       setTimeout(() => {
         this._reConnectTimes--;
-        this._connect(() => {
-          this._reConnectTimes = this.options.reConnectTimes;
-          // try to recover
-          this._resume();
+        this._connect(err => {
+          if (!err) {
+            this._reConnectTimes = this.options.reConnectTimes;
+            // try to recover
+            this._resume();
+          }
         });
       }, this.options.reConnectInterval);
       return;
     }
-    this._cleanQueue(err);
+    this._cleanQueue(this._lastError);
     this.emit('close');
-    this.removeAllListeners();
   }
 
   _connect(done) {
     if (!done) {
-      done = () => this.ready(true);
+      done = err => {
+        this.ready(err ? err : true);
+      };
     }
-
     const socket = this._socket = net.connect(this.options.port, this.options.host);
     socket.setNoDelay(this.options.noDelay);
     socket.on('readable', () => {
@@ -393,35 +401,52 @@ class TCPBase extends Base {
       }
     });
 
-    // receive `end` event that means the other end of the socket sends a FIN packet
-    socket.once('end', () => {
-      this.logger.info('[tcp-base] the connection: %s is closed by other side', this[addressKey]);
-    });
     socket.once('close', () => this._handleClose());
     socket.once('error', err => {
       err.message += ' (address: ' + this[addressKey] + ')';
+      this._lastError = err;
+      if (err.code === 'ECONNRESET') {
+        this.logger.warn('[TCPBase] socket is closed by other side while there were still unhandled data in the socket buffer');
+      } else {
+        this.emit('error', err);
+      }
+    });
+    socket.setTimeout(this.options.connectTimeout, () => {
+      const err = new Error(`[TCPBase] socket connect timeout (${this.options.connectTimeout}ms)`);
+      err.name = 'TcpConnectionTimeoutError';
+      err.host = this.options.host;
+      err.port = this.options.port;
       this.close(err);
     });
 
-    socket.once('connect', done);
+    socket.once('connect', () => {
+      // set timeout back to zero after connected
+      socket.setTimeout(0);
+      this.emit('connect');
+    });
 
-    if (this.options.needHeartbeat) {
-      this._heartbeatTimer = setInterval(() => {
-        const duration = this._lastHeartbeatTime - this._lastReceiveDataTime;
-        if (this._lastReceiveDataTime && duration > this.options.heartbeatInterval) {
-          const err = new Error(`server ${this[addressKey]} no response in ${duration}ms, maybe the socket is end on the other side.`);
-          err.name = 'ServerNoResponseError';
-          this.close(err);
-          return;
-        }
-        // flow control
-        if (this._invokes.size > 0 || !this.isOK) {
-          return;
-        }
-        this._lastHeartbeatTime = Date.now();
-        this.sendHeartBeat();
-      }, this.options.heartbeatInterval);
-    }
+    Promise.race([
+      this.await('connect'),
+      this.await('error'),
+    ]).then(done, done);
+  }
+
+  _startHeartbeat() {
+    this._heartbeatTimer = setInterval(() => {
+      const duration = this._lastHeartbeatTime - this._lastReceiveDataTime;
+      if (this._lastReceiveDataTime && duration > this.options.heartbeatInterval) {
+        const err = new Error(`server ${this[addressKey]} no response in ${duration}ms, maybe the socket is end on the other side.`);
+        err.name = 'ServerNoResponseError';
+        this.close(err);
+        return;
+      }
+      // flow control
+      if (this._invokes.size > 0 || !this.isOK) {
+        return;
+      }
+      this._lastHeartbeatTime = Date.now();
+      this.sendHeartBeat();
+    }, this.options.heartbeatInterval);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "npm run lint && npm run test-local",
     "test-local": "egg-bin test",
     "cov": "egg-bin cov",
-    "ci": "npm run lint && npm run cov"
+    "ci": "npm run lint && npm run cov",
+    "contributors": "contributors"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "lib"
   ],
   "scripts": {
-    "autod": "autod -w --prefix '^'",
-    "lint": "eslint --ext .js lib test example",
+    "autod": "autod",
+    "lint": "eslint --ext .js .",
     "test": "npm run lint && npm run test-local",
     "test-local": "egg-bin test",
     "cov": "egg-bin cov",
@@ -34,17 +34,19 @@
     "version": "6, 7"
   },
   "devDependencies": {
-    "autod": "^2.7.1",
-    "egg-bin": "^2.2.0",
-    "egg-ci": "^1.1.0",
-    "eslint": "^3.15.0",
+    "autod": "^2.8.0",
+    "contributors": "^0.5.1",
+    "egg-bin": "^3.3.0",
+    "egg-ci": "^1.6.0",
+    "eslint": "^3.19.0",
     "eslint-config-egg": "^3.2.0",
     "mm": "^2.1.0",
-    "npminstall": "^2.24.0",
+    "mz-modules": "^1.0.0",
+    "npminstall": "^2.29.1",
     "pedding": "^1.1.0"
   },
   "dependencies": {
     "is-type-of": "^1.0.0",
-    "sdk-base": "^3.1.0"
+    "sdk-base": "^3.1.1"
   }
 }

--- a/test/close_wait.test.js
+++ b/test/close_wait.test.js
@@ -78,6 +78,7 @@ describe('test/close_wait.test.js', () => {
       client.on('close', done);
       client.on('error', err => {
         assert(err);
+        console.log(err);
         assert(err.name === 'ServerNoResponseError');
         assert(/server 127.0.0.1:9600 no response in \d+ms, maybe the socket is end on the other side/i.test(err.message));
         done();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

1. fix invoke oneway after close issue
2. remove reconnect support