### PR TITLE
fix: socket.on('error') instead of once

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -395,7 +395,7 @@ class TCPBase extends Base {
     socket.setNoDelay(this.options.noDelay);
     socket.on('readable', () => { this._handleReadable(); });
     socket.once('close', () => { this._handleClose(); });
-    socket.once('error', err => {
+    socket.on('error', err => {
       err.message += ' (address: ' + this[addressKey] + ')';
       this._lastError = err;
       if (err.code === 'ECONNRESET') {

--- a/lib/base.js
+++ b/lib/base.js
@@ -219,6 +219,10 @@ class TCPBase extends Base {
       meta,
       packet,
       timer: setTimeout(() => {
+        if (!this._socket) {
+          return;
+        }
+
         meta.bufferSize2 = this._socket.bufferSize;
         meta.endTime = endTime;
         this._finishInvoke(packet.id);

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const TCPBase = require('../');
+const server = require('./support/server_immidiate_end');
+
+describe('test/error.test.js', () => {
+  class Client extends TCPBase {
+    constructor(options) {
+      Object.assign(options, {
+        headerLength: 8,
+        heartbeatInterval: 3000,
+      });
+
+      super(options);
+    }
+
+    getBodyLength(header) {
+      return header.readInt32BE(0);
+    }
+
+    decode(buf, header) {
+      let data;
+      if (buf) {
+        data = JSON.parse(buf);
+      }
+      return {
+        id: header.readInt32BE(4),
+        data,
+      };
+    }
+
+    get heartBeatPacket() {
+      return makeRequest(1).data;
+    }
+  }
+
+  function makeRequest(id, content, oneway) {
+    const header = Buffer.alloc(8);
+    header.fill(0);
+    const body = Buffer.from(JSON.stringify(content || {
+      id,
+      message: 'hello',
+    }));
+    header.writeInt32BE(body.length, 0);
+    header.writeInt32BE(id, 4);
+    return {
+      id,
+      oneway,
+      data: Buffer.concat([ header, body ]),
+    };
+  }
+
+  describe('end by server', () => {
+    it('should not throw uncaughtExeception if socket has been destroyed', done => {
+      server.start(9090, () => {
+        const client = new Client({
+          host: '127.0.0.1',
+          port: 9090,
+        });
+
+        client.once('connect', () => {
+          client.send({ data: 'foo' });
+          server.close();
+          client.send({ data: 'foo' });
+        });
+        client.on('error', err => err);
+        client.on('close', () => console.log('close'));
+        setTimeout(done, 5000);
+      });
+    });
+  });
+
+});

--- a/test/support/server_immidiate_end.js
+++ b/test/support/server_immidiate_end.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const net = require('net');
+
+let server;
+const connections = [];
+
+exports.start = function(port, cb) {
+  server = net.createServer({
+    allowHalfOpen: true,
+  }, socket => {
+    socket.write(Buffer.from('0000001a000000007b226964223a302c226d657373616765223a2268656c6c6f227d', 'hex'));
+    console.log('socket connect', socket.remoteAddress);
+    socket.on('data', data => {
+      console.log('receive', data.toString());
+    });
+
+    connections.push(socket);
+  });
+  server.listen(port, cb);
+};
+
+exports.close = function() {
+  connections.forEach(conn => conn.destroy());
+  server && server.close();
+};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
目前对 `socket` 的 `error` 事件只侦听一次，如果 `socket` 在 `destroy` 前抛出多次 `error`，会产生 `uncaughtException`，导致进程异常退出。

此外，在非 `oneway` 模式下，对于重复的 `pack.id`，由于默认设置的超时兜底函数会被覆盖，导致 `_invokes` 在处理退出的场景下无法清理干净所有未处理请求的兜底超时函数，而此时 `_socket` 已经被置为 `null`，这样重复的超时函数也会产生 `uncaughtException` 导致进程异常退出，参见 [测试用例](https://github.com/node-modules/tcp-base/pull/13/files#diff-ae2bafab3d0742ad51d99945e79114e8ad74e0b6dcfe291797b3433f59f8b130R62-R64)